### PR TITLE
Add Support for Dot Files in excludeFiles Setting

### DIFF
--- a/src/Utils.ts
+++ b/src/Utils.ts
@@ -40,7 +40,7 @@ export function shouldExcludeFile(file: string): boolean {
     if (Settings.buildInRegexToExclude.find((regex) => Array.isArray(file.match(regex))) !== undefined) {
         return true;
     }
-    return minimatch(this.relativePath(file), Settings.excludeFiles);
+    return minimatch(this.relativePath(file), Settings.excludeFiles, {dot: true});
 }
 
 /**


### PR DESCRIPTION
Currently, the `excludeFiles` setting does not support dot files (files beginning with a `.`), which means that all dot files and all files inside dot directories are always included. This pull request allows dot files to be excluded.

For example, with the default setting for `excludeFiles` (`**/*.+(git|rendered)`), files in the `.git` directory are NOT excluded. You can test this by running this command in node:
```javascript
var minimatch = require('minimatch');
console.log(minimatch('/home/me/repo/.git', '**/*.+(git|rendered)')); // false
```

The only change in this pull request is one line in `src/Utils.ts`, where I added a parameter to the call to `minimatch`.

The impact of this change to users is that more files can be excluded with the `excludeFiles` setting.

For users who use the *default* `excludeFiles` setting, the only impact of this change is that files whose basename ends with `.git` or `.rendered` will be excluded. (Files in `.git` and `.rendered` directories will still NOT be excluded because the default `excludeFiles` setting only matches files which *end with* `.git` or `.rendered`.)

For users who have a *custom* `excludeFiles` setting, the impact of this change is that this extension might ignore dot files and files inside dot directories when it previously did not.